### PR TITLE
prebuild: pinpoint error messages to line, column, and type of action.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ __xtuml_lextab.py
 __xtuml_parsetab.py
 __oal_lextab.py
 __oal_parsetab.py
+build
+dist
+pyxtuml.egg-info
+.history

--- a/bridgepoint/oal.py
+++ b/bridgepoint/oal.py
@@ -2013,9 +2013,7 @@ class OALParser(object):
     
     def p_error(self, p):
         if p:
-            raise ParseException("invalid token '%s' at %s:%s" % (p.type,
-                                                                  p.lineno,
-                                                                  find_column(p.lexer.lexdata, p.lexpos)))
+            raise ParseException("invalid token '%s' at line: %s, column: %s" % (p.type,p.lineno, find_column(p.lexer.lexdata, p.lexpos)))
         else:
             raise ParseException("unknown parsing error")
 

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ class TestCommand(Command):
 
 
 setup(name='pyxtuml',
-      version='2.2.1', # ensure that this is the same as in xtuml.version
+      version='2.2.2', # ensure that this is the same as in xtuml.version
       description='Library for parsing, manipulating, and generating BridgePoint xtUML models',
       author=u'John Törnblom',
       author_email='john.tornblom@gmail.com',

--- a/xtuml/version.py
+++ b/xtuml/version.py
@@ -19,6 +19,6 @@
 name = 'pyxtuml'
 date = '2020-03-12'
 version = '2.2'
-release = '2.2.1'  # ensure that this is the same as in setup.py
+release = '2.2.2'  # ensure that this is the same as in setup.py
 
 complete_string = '%s v%s (%s)' % (name, release, date)


### PR DESCRIPTION
Specifically;
- extend Action prebuilders such that all return a valid label,
- extend Action prebuilders to include an element_type attribute for clearly logging information,
- add get_event_name function allowing properly labeling for these cases:
    * Polymorphic Event Local
    * Polymorphic Event Non Local
    * Polymorphic Event orphaned
    * Signal Event
    * Local Event